### PR TITLE
Resolve TODO: derive stable key for AudioItem from audio data fields

### DIFF
--- a/compose-for-agents/agno/agent-ui/src/components/playground/ChatArea/Messages/Multimedia/Audios/Audios.tsx
+++ b/compose-for-agents/agno/agent-ui/src/components/playground/ChatArea/Messages/Multimedia/Audios/Audios.tsx
@@ -52,8 +52,15 @@ AudioItem.displayName = 'AudioItem'
 const Audios = memo(({ audio }: { audio: AudioData[] }) => (
   <div className="flex flex-col gap-4">
     {audio.map((audio_item, index) => (
-      // TODO :: find a better way to handle the key
-      <AudioItem key={audio_item.id ?? `audio-${index}`} audio={audio_item} />
+      <AudioItem
+        key={
+          audio_item.id ??
+          audio_item.url ??
+          (audio_item.base64_audio ?? audio_item.content)?.slice(0, 32) ??
+          `audio-${index}`
+        }
+        audio={audio_item}
+      />
     ))}
   </div>
 ))


### PR DESCRIPTION
Priority order: id > url > first 32 chars of base64_audio/content > index fallback.
This avoids React key instability when items are reordered or inserted, without
relying solely on the positional index.

https://claude.ai/code/session_01MfKf24YTyqh2dmvWqUBk5n